### PR TITLE
Update README with URL and add workflow test

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ npm start
 npm test
 ```
 
-## デプロイ例（GitHub Pages）
+## GitHub Pages
 ```
-https://<ユーザー名>.github.io/<リポジトリ名>/
+https://femon07.github.io/tetris/
 ```
 
 ## 操作方法

--- a/tests/deploy.test.js
+++ b/tests/deploy.test.js
@@ -1,0 +1,13 @@
+const fs = require('fs');
+const yaml = require('js-yaml');
+
+describe('deploy workflow', () => {
+  test('triggers on main branch push and deploys to gh-pages', () => {
+    const text = fs.readFileSync('.github/workflows/deploy.yml', 'utf8');
+    const config = yaml.load(text);
+    const branches = config.on.push.branches;
+    expect(branches).toContain('main');
+    const uses = config.jobs.build.steps.map(s => s.uses).filter(Boolean);
+    expect(uses).toContain('peaceiris/actions-gh-pages@v3');
+  });
+});


### PR DESCRIPTION
## 概要
- README の GitHub Pages URL を実際の URL に修正しました
- deploy workflow が main ブランチの push を契機に gh-pages ブランチへデプロイする設定になっていることを確認するテストを追加しました

## テスト
- `npm test` を実行し、すべてのテストが成功することを確認しました

------
https://chatgpt.com/codex/tasks/task_e_684cc2776c688321a1d0537c0bda0115