### PR TITLE
GitHub Pagesデプロイ権限の修正とテスト追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: write
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ npm start
 npm test
 ```
 
-## デプロイ例（GitHub Pages）
+## GitHub Pages
 ```
-https://<ユーザー名>.github.io/<リポジトリ名>/
+https://femon07.github.io/tetris/
 ```
 
 ## 操作方法

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "babel-loader": "^10.0.0",
         "jest": "^30.0.0",
         "jest-environment-jsdom": "^30.0.0",
+        "js-yaml": "^4.1.0",
         "jsdom": "^26.1.0",
         "webpack": "^5.99.9",
         "webpack-cli": "^6.0.1"
@@ -1963,6 +1964,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -1975,6 +1986,20 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
@@ -3881,14 +3906,11 @@
       }
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "license": "Python-2.0"
     },
     "node_modules/babel-jest": {
       "version": "30.0.0",
@@ -6935,14 +6957,13 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "babel-loader": "^10.0.0",
     "jest": "^30.0.0",
     "jest-environment-jsdom": "^30.0.0",
+    "js-yaml": "^4.1.0",
     "jsdom": "^26.1.0",
     "webpack": "^5.99.9",
     "webpack-cli": "^6.0.1"

--- a/tests/deploy.test.js
+++ b/tests/deploy.test.js
@@ -1,0 +1,14 @@
+const fs = require('fs');
+const yaml = require('js-yaml');
+
+describe('deploy workflow', () => {
+  test('triggers on main branch push and deploys to gh-pages', () => {
+    const text = fs.readFileSync('.github/workflows/deploy.yml', 'utf8');
+    const config = yaml.load(text);
+    const branches = config.on.push.branches;
+    expect(branches).toContain('main');
+    const uses = config.jobs.build.steps.map(s => s.uses).filter(Boolean);
+    expect(uses).toContain('peaceiris/actions-gh-pages@v3');
+    expect(config.permissions.contents).toBe('write');
+  });
+});


### PR DESCRIPTION
## 概要
- `deploy.yml` に `permissions` を追加し、`GITHUB_TOKEN` が push できるよう修正
- GitHub Pages デプロイ設定を検証するテストを更新
- `js-yaml` を開発依存として追加

## テスト
- `npm test` を実行し、すべてのテストが成功することを確認

------
https://chatgpt.com/codex/tasks/task_e_684cc2776c688321a1d0537c0bda0115