### PR TITLE
Skip tests when codex already ran them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,14 @@ jobs:
         with:
           node-version: '18'
           cache: 'npm'
+      - id: skip
+        run: |
+          if git log -1 --pretty=%B | grep -q '\[codex skip ci\]'; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
       - run: npm ci
       - run: npm test --silent
+        if: steps.skip.outputs.skip != 'true'
       - run: npm run build

--- a/tests/ci.test.js
+++ b/tests/ci.test.js
@@ -1,0 +1,14 @@
+const fs = require('fs');
+const yaml = require('js-yaml');
+
+describe('ci workflow', () => {
+  test('has conditional skip for codex', () => {
+    const text = fs.readFileSync('.github/workflows/ci.yml', 'utf8');
+    const config = yaml.load(text);
+    const steps = config.jobs.build.steps;
+    const skipStep = steps.find(s => s.id === 'skip');
+    expect(skipStep).toBeTruthy();
+    const testStep = steps.find(s => s.run && s.run.includes('npm test'));
+    expect(testStep.if).toBe("steps.skip.outputs.skip != 'true'");
+  });
+});


### PR DESCRIPTION
## Summary
- adjust CI workflow to skip tests when commit msg includes `[codex skip ci]`
- add unit test to check for the skip condition

## Testing
- `npm test -- tests --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_684ce96466748321b6e29dcce0b95bb5