### PR TITLE
Fix GitHub Pages build output

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Tetris</title>
+</head>
+<body>
+  <h1>Tetris</h1>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/docs/main.js
+++ b/docs/main.js
@@ -1,0 +1,1 @@
+(()=>{var r={397:r=>{r.exports={calculateScore:function(r,t=0){return t+({1:40,2:100,3:300,4:1200}[r]||0)}}}},t={};!function e(o){var n=t[o];if(void 0!==n)return n.exports;var u=t[o]={exports:{}};return r[o](u,u.exports,e),u.exports}(397)})();

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "prebuild": "node scripts/prebuild.js",
     "build": "webpack",
     "test": "jest",
-    "postbuild": "cp index.html dist/index.html"
+    "postbuild": "cp index.html dist/index.html && mkdir -p docs && cp dist/index.html docs/index.html && cp dist/main.js docs/main.js"
   },
   "keywords": [],
   "author": "",

--- a/tests/docs.test.js
+++ b/tests/docs.test.js
@@ -1,0 +1,10 @@
+const fs = require('fs');
+const { execSync } = require('child_process');
+
+describe('docs build', () => {
+  test('docs フォルダにビルド結果が存在する', () => {
+    execSync('npm run build', { stdio: 'ignore' });
+    expect(fs.existsSync('docs/index.html')).toBe(true);
+    expect(fs.existsSync('docs/main.js')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- ビルド後に `docs` ディレクトリへ成果物をコピーするようスクリプトを更新
- `docs` ディレクトリを追加
- `docs` にファイルが生成されるか確認するテストを追加

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cea815b508321b8137ad478777150