### PR TITLE
Fix GitHub Pages path

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,6 @@
 </head>
 <body>
   <h1>Tetris</h1>
-  <script src="main.js"></script>
+  <script src="./main.js"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "tetris",
   "version": "1.0.0",
+  "homepage": "https://femon07.github.io/tetris",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -1,0 +1,13 @@
+const fs = require('fs');
+const webpackConfig = require('../webpack.config');
+
+describe('config settings for GitHub Pages', () => {
+  test('package.json has correct homepage', () => {
+    const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+    expect(pkg.homepage).toBe('https://femon07.github.io/tetris');
+  });
+
+  test('webpack publicPath is empty string', () => {
+    expect(webpackConfig.output.publicPath).toBe('');
+  });
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,7 @@ module.exports = {
   output: {
     filename: 'main.js',
     path: path.resolve(__dirname, 'dist'),
+    publicPath: '',
   },
   mode: 'production',
 };


### PR DESCRIPTION
## Summary
- GitHub Pagesで404となる問題を修正
- `webpack.config.js`で`publicPath`を設定
- `index.html`のスクリプトパスを相対パスに変更
- `package.json`に`homepage`を追加
- GitHub Pages向け設定を検証するテストを追加

## Testing
- `npm test -- -i`
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_684cea815b508321b8137ad478777150