### PR TITLE
Fix root screen build output

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "prebuild": "node scripts/prebuild.js",
     "build": "webpack",
     "test": "jest",
-    "postbuild": "cp index.html dist/index.html && mkdir -p docs && cp dist/index.html docs/index.html && cp dist/main.js docs/main.js"
+    "postbuild": "cp index.html dist/index.html && mkdir -p docs && cp dist/index.html docs/index.html && cp dist/main.js docs/main.js && cp dist/main.js main.js"
   },
   "keywords": [],
   "author": "",

--- a/tests/rootScreen.test.js
+++ b/tests/rootScreen.test.js
@@ -1,0 +1,14 @@
+const fs = require('fs');
+const { execSync } = require('child_process');
+
+describe('ルート画面でテトリスが表示される', () => {
+  beforeAll(() => {
+    execSync('npm run build', { stdio: 'ignore' });
+  });
+
+  test('index.htmlがmain.jsを参照し、ファイルが存在する', () => {
+    const html = fs.readFileSync('index.html', 'utf8');
+    expect(html).toMatch(/<script src="\.\/main.js"><\/script>/);
+    expect(fs.existsSync('main.js')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- ビルド後に生成される main.js をルートにも配置するように修正
- ルート画面でテトリスが表示できるか確認するテストを追加

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d0b2717188321a35d9ae65d12c5a0