### PR TITLE
Add calculateLevel function

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -3,6 +3,10 @@ function calculateScore(linesCleared, currentScore = 0) {
   return currentScore + (scoreTable[linesCleared] || 0);
 }
 
+function calculateLevel(totalLines, linesPerLevel = 10) {
+  return Math.floor(totalLines / linesPerLevel) + 1;
+}
+
 function initGame() {
   const canvas = document.getElementById('game');
   if (!canvas) return;
@@ -165,4 +169,4 @@ if (typeof window !== 'undefined') {
   window.addEventListener('DOMContentLoaded', initGame);
 }
 
-module.exports = { calculateScore, initGame };
+module.exports = { calculateScore, calculateLevel, initGame };

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -1,4 +1,4 @@
-const { calculateScore } = require('../src/game');
+const { calculateScore, calculateLevel } = require('../src/game');
 
 describe('calculateScore', () => {
   test('1 line', () => {
@@ -15,5 +15,20 @@ describe('calculateScore', () => {
   });
   test('no lines', () => {
     expect(calculateScore(0, 50)).toBe(50);
+  });
+});
+
+describe('calculateLevel', () => {
+  test('0 lines -> level 1', () => {
+    expect(calculateLevel(0)).toBe(1);
+  });
+  test('9 lines -> level 1', () => {
+    expect(calculateLevel(9)).toBe(1);
+  });
+  test('10 lines -> level 2', () => {
+    expect(calculateLevel(10)).toBe(2);
+  });
+  test('25 lines -> level 3', () => {
+    expect(calculateLevel(25)).toBe(3);
   });
 });


### PR DESCRIPTION
## 概要
- ライン消去数からレベルを計算する `calculateLevel` 関数を追加
- それに対応するテストを `tests/game.test.js` に実装

## テスト結果
- `npm ci` 実行後、`npx jest tests/*.test.js --runInBand` を実行し、8件のテストスイートが成功することを確認【e4f02e†L1-L5】

------
https://chatgpt.com/codex/tasks/task_e_684d25ffe0f083218918901e2272f127