### PR TITLE
remove duplicate gamestate

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -361,7 +361,6 @@ export function init() {
       handleKeyDown,
       handleKeyUp,
       setupEventListeners,
-      gameState,
       eventManager,
       initGame,
       resetGame,

--- a/tests/game/InitReturn.test.js
+++ b/tests/game/InitReturn.test.js
@@ -1,0 +1,44 @@
+import { init } from '../../src/game.js';
+
+describe('init関数の返り値', () => {
+  beforeEach(() => {
+    document.body.innerHTML = [
+      '<canvas id="game"></canvas>',
+      '<canvas id="next-piece-canvas"></canvas>',
+      '<div id="score"></div>',
+      '<div id="lines"></div>',
+      '<div id="level"></div>'
+    ].join('');
+
+    const canvas = document.getElementById('game');
+    canvas.getContext = jest.fn(() => ({
+      fillRect: jest.fn(),
+      clearRect: jest.fn(),
+    }));
+
+    document.addEventListener = jest.fn();
+    document.removeEventListener = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('返り値のキー一覧を確認する', () => {
+    const result = init();
+    expect(result).not.toBeNull();
+    const keys = Object.keys(result).sort();
+    const expected = [
+      'canvas',
+      'eventManager',
+      'gameState',
+      'handleKeyDown',
+      'handleKeyUp',
+      'initGame',
+      'resetGame',
+      'setupEventListeners',
+      'update',
+    ].sort();
+    expect(keys).toEqual(expected);
+  });
+});


### PR DESCRIPTION
## Summary
- `init` の返り値から重複していた `gameState` を削除
- 返り値のキーを確認するテストを追加

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6850ffb7fae08321a3f3f9f2c00de1f8