### PR TITLE
Call init on DOMContentLoaded and add test

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,8 @@ document.addEventListener('DOMContentLoaded', () => {
     } else {
       console.error('キャンバス要素が見つかりません');
     }
+    // ゲームを開始
+    init();
   } catch (error) {
     console.error('ゲームの初期化中にエラーが発生しました:', error);
     alert('ゲームの初期化中にエラーが発生しました。コンソールを確認してください。');

--- a/tests/index/AutoStart.test.js
+++ b/tests/index/AutoStart.test.js
@@ -1,0 +1,27 @@
+import { jest } from '@jest/globals';
+
+jest.mock('../../src/styles.css', () => ({}), { virtual: true });
+
+let init;
+
+beforeEach(() => {
+  jest.resetModules();
+  jest.doMock('../../src/game.js', () => ({
+    init: jest.fn(),
+  }));
+  ({ init } = require('../../src/game.js'));
+  document.body.innerHTML = '<canvas id="game"></canvas>';
+});
+describe('index.js 自動起動テスト', () => {
+  test('DOMContentLoaded で init が呼び出される', () => {
+    const addSpy = jest.spyOn(document, 'addEventListener');
+    jest.isolateModules(() => {
+      require('../../src/index.js');
+    });
+    const call = addSpy.mock.calls.find(c => c[0] === 'DOMContentLoaded');
+    expect(call).toBeDefined();
+    const handler = call[1];
+    handler();
+    expect(init).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- DOMContentLoaded イベント発火時に `init()` を実行
- `index.js` が自動でゲームを開始するか確認するテストを追加

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68510133b81083218aec712d5c21c64f