### PR TITLE
Refactor tests with shared helpers and japanese titles

### DIFF
--- a/tests/core/Board.test.js
+++ b/tests/core/Board.test.js
@@ -1,58 +1,58 @@
 import { Board } from '../../src/core/Board';
 import { Piece } from '../../src/core/Piece';
 
-describe('Board', () => {
+describe('Board クラス', () => {
   let board;
 
   beforeEach(() => {
     board = new Board(10, 20); // 10x20のボードを初期化
   });
 
-  test('should initialize with empty grid', () => {
+  test('空のグリッドで初期化される', () => {
     const emptyGrid = Array.from({ length: 20 }, () => Array(10).fill(0));
     expect(board.grid).toEqual(emptyGrid);
   });
 
-  test('should clear the grid', () => {
+  test('グリッドをクリアできる', () => {
     board.grid[0][0] = 1; // 適当な値を設定
     board.clear();
     const emptyGrid = Array.from({ length: 20 }, () => Array(10).fill(0));
     expect(board.grid).toEqual(emptyGrid);
   });
 
-  test('isInside should return true for valid coordinates', () => {
+  test('isInside は有効な座標で true を返す', () => {
     expect(board.isInside(0, 0)).toBe(true);
     expect(board.isInside(9, 19)).toBe(true);
     expect(board.isInside(5, 10)).toBe(true);
   });
 
-  test('isInside should return false for invalid coordinates', () => {
+  test('isInside は無効な座標で false を返す', () => {
     expect(board.isInside(-1, 0)).toBe(false);
     expect(board.isInside(0, -1)).toBe(false);
     expect(board.isInside(10, 0)).toBe(false);
     expect(board.isInside(0, 20)).toBe(false);
   });
 
-  test('isEmpty should return true for empty cells', () => {
+  test('isEmpty は空セルで true を返す', () => {
     expect(board.isEmpty(0, 0)).toBe(true);
     board.grid[0][0] = 1; // 埋める
     expect(board.isEmpty(0, 0)).toBe(false);
   });
 
-  test('setCell should set the value of a cell', () => {
+  test('setCell は指定セルに値を設定する', () => {
     board.setCell(0, 0, 1);
     expect(board.grid[0][0]).toBe(1);
     board.setCell(9, 19, 5);
     expect(board.grid[19][9]).toBe(5);
   });
 
-  test('getCell should return the value of a cell', () => {
+  test('getCell はセルの値を返す', () => {
     board.setCell(1, 1, 2);
     expect(board.getCell(1, 1)).toBe(2);
     expect(board.getCell(100, 100)).toBeNull(); // 範囲外
   });
 
-  test('merge should merge a piece onto the board', () => {
+  test('merge はピースをボードに統合する', () => {
     const matrix = [
       [1, 1],
       [1, 1]
@@ -65,7 +65,7 @@ describe('Board', () => {
     expect(board.grid[1][1]).toBe(1);
   });
 
-  test('clearLines should clear full lines and return count', () => {
+  test('clearLines は揃った行を消して数を返す', () => {
     // 1行目を全て埋める
     for (let i = 0; i < board.cols; i++) {
       board.setCell(i, 0, 1);

--- a/tests/core/Game.test.js
+++ b/tests/core/Game.test.js
@@ -6,7 +6,7 @@ import { Piece } from '../../src/core/Piece.js';
 jest.mock('../../src/core/Board.js');
 jest.mock('../../src/core/Piece.js');
 
-describe('Game', () => {
+describe('Game クラス', () => {
   let game;
   let mockBoardInstance;
   let mockPieceInstance;
@@ -71,7 +71,7 @@ describe('Game', () => {
     expect(game.piece).toBe(mockPieceInstance);
   });
 
-  describe('dropPiece', () => {
+  describe('dropPiece メソッド', () => {
     beforeEach(() => {
       game = new Game();
       game.reset();
@@ -116,7 +116,7 @@ describe('Game', () => {
     });
   });
 
-  describe('movePiece', () => {
+  describe('movePiece メソッド', () => {
     beforeEach(() => {
       game = new Game();
       game.reset();
@@ -136,7 +136,7 @@ describe('Game', () => {
     });
   });
 
-  describe('rotatePiece', () => {
+  describe('rotatePiece メソッド', () => {
     beforeEach(() => {
       game = new Game();
       game.reset();
@@ -158,7 +158,7 @@ describe('Game', () => {
     });
   });
 
-  describe('hasCollision', () => {
+  describe('hasCollision メソッド', () => {
     beforeEach(() => {
       game = new Game();
       game.reset();

--- a/tests/core/Piece.test.js
+++ b/tests/core/Piece.test.js
@@ -1,6 +1,6 @@
 import { Piece } from '../../src/core/Piece';
 
-describe('Piece', () => {
+describe('Piece クラス', () => {
   let piece;
 
   beforeEach(() => {
@@ -12,7 +12,7 @@ describe('Piece', () => {
     piece = new Piece(matrix);
   });
 
-  test('should initialize with given matrix and position', () => {
+  test('行列と座標で初期化される', () => {
     const initialMatrix = [
       [1, 1],
       [1, 1]
@@ -22,14 +22,14 @@ describe('Piece', () => {
     expect(piece.pos).toEqual(initialPos);
   });
 
-  test('should move the piece by given delta x and y', () => {
+  test('指定量だけ移動する', () => {
     piece.move(1, 2);
     expect(piece.pos).toEqual({ x: 1, y: 2 });
     piece.move(-1, -1);
     expect(piece.pos).toEqual({ x: 0, y: 1 });
   });
 
-  test('should rotate the piece clockwise', () => {
+  test('時計回りに回転する', () => {
     const matrix = [
       [0, 1, 0],
       [1, 1, 1],
@@ -45,7 +45,7 @@ describe('Piece', () => {
     expect(piece.matrix).toEqual(expectedMatrix);
   });
 
-  test('should rotate the piece counter-clockwise', () => {
+  test('反時計回りに回転する', () => {
     const matrix = [
       [0, 1, 0],
       [1, 1, 1],

--- a/tests/event/EventManager.test.js
+++ b/tests/event/EventManager.test.js
@@ -1,6 +1,6 @@
 import { EventManager } from '../../src/event/EventManager';
 
-describe('EventManager', () => {
+describe('EventManager クラス', () => {
   let eventManager;
   let mockHandler;
 
@@ -17,20 +17,20 @@ describe('EventManager', () => {
     jest.restoreAllMocks();
   });
 
-  test('constructor should initialize eventHandlers map', () => {
+  test('コンストラクタはeventHandlersマップを初期化する', () => {
     expect(eventManager.eventHandlers).toBeInstanceOf(Map);
     expect(eventManager.eventHandlers.size).toBe(0);
   });
 
-  describe('addEventListener', () => {
-    test('should add an event listener', () => {
+  describe('addEventListener メソッド', () => {
+    test('イベントリスナーを追加できる', () => {
       eventManager.addEventListener('keydown', mockHandler);
       expect(eventManager.eventHandlers.get('keydown').has(mockHandler)).toBe(true);
       expect(document.addEventListener).toHaveBeenCalledWith('keydown', expect.any(Function));
       expect(document.addEventListener).toHaveBeenCalledTimes(1);
     });
 
-    test('should add multiple handlers for the same event type', () => {
+    test('同じ種類のイベントに複数のハンドラを登録できる', () => {
       const anotherHandler = jest.fn();
       eventManager.addEventListener('keydown', mockHandler);
       eventManager.addEventListener('keydown', anotherHandler);
@@ -39,7 +39,7 @@ describe('EventManager', () => {
       expect(document.addEventListener).toHaveBeenCalledTimes(1); // Should only be called once per eventType
     });
 
-    test('should return a function to remove the event listener', () => {
+    test('削除用関数を返す', () => {
       const remove = eventManager.addEventListener('keyup', mockHandler);
       expect(typeof remove).toBe('function');
       expect(eventManager.eventHandlers.get('keyup').has(mockHandler)).toBe(true);
@@ -50,8 +50,8 @@ describe('EventManager', () => {
     });
   });
 
-  describe('removeEventListener', () => {
-    test('should remove an event listener', () => {
+  describe('removeEventListener メソッド', () => {
+    test('イベントリスナーを削除できる', () => {
       eventManager.addEventListener('keydown', mockHandler);
       eventManager.removeEventListener('keydown', mockHandler);
       expect(eventManager.eventHandlers.has('keydown')).toBe(false);
@@ -59,7 +59,7 @@ describe('EventManager', () => {
       expect(document.removeEventListener).toHaveBeenCalledTimes(1);
     });
 
-    test('should not remove event listener if handler does not exist', () => {
+    test('存在しないハンドラは削除しない', () => {
       eventManager.addEventListener('keydown', mockHandler);
       const nonExistentHandler = jest.fn();
       eventManager.removeEventListener('keydown', nonExistentHandler);
@@ -67,14 +67,14 @@ describe('EventManager', () => {
       expect(document.removeEventListener).not.toHaveBeenCalled();
     });
 
-    test('should not remove event listener if event type does not exist', () => {
+    test('存在しないイベント種類では削除しない', () => {
       eventManager.removeEventListener('nonexistent', mockHandler);
       expect(document.removeEventListener).not.toHaveBeenCalled();
     });
   });
 
-  describe('removeAllEventListeners', () => {
-    test('should remove all event listeners', () => {
+  describe('removeAllEventListeners メソッド', () => {
+    test('すべてのイベントリスナーを削除できる', () => {
       const handler1 = jest.fn();
       const handler2 = jest.fn();
       eventManager.addEventListener('keydown', handler1);
@@ -85,31 +85,31 @@ describe('EventManager', () => {
     });
   });
 
-  describe('triggerEvent', () => {
-    test('should call registered handlers for the event type', () => {
+  describe('triggerEvent メソッド', () => {
+    test('登録済みハンドラが呼び出される', () => {
       eventManager.addEventListener('testEvent', mockHandler);
       eventManager.triggerEvent('testEvent');
       expect(mockHandler).toHaveBeenCalledTimes(1);
     });
 
-    test('should pass event properties to the handler', () => {
+    test('イベントオブジェクトが渡される', () => {
       eventManager.addEventListener('testEvent', mockHandler);
       const eventProps = { key: 'ArrowUp', code: 'ArrowUp' };
       eventManager.triggerEvent('testEvent', eventProps);
       expect(mockHandler).toHaveBeenCalledWith(expect.objectContaining(eventProps));
     });
 
-    test('should not call handlers for other event types', () => {
+    test('登録されていない種類のイベントでは呼び出されない', () => {
       eventManager.addEventListener('testEvent', mockHandler);
       eventManager.triggerEvent('anotherEvent');
       expect(mockHandler).not.toHaveBeenCalled();
     });
 
-    test('should not throw error if no handlers are registered for event type', () => {
+    test('ハンドラ未登録でもエラーにならない', () => {
       expect(() => eventManager.triggerEvent('nonExistentEvent')).not.toThrow();
     });
 
-    test('should handle errors in event handlers gracefully', () => {
+    test('ハンドラでの例外を握りつぶす', () => {
       const erroringHandler = jest.fn(() => { throw new new Error('Test Error'); });
       eventManager.addEventListener('errorEvent', erroringHandler);
       jest.spyOn(console, 'error').mockImplementation(() => {}); // Suppress console error during test
@@ -119,7 +119,7 @@ describe('EventManager', () => {
       console.error.mockRestore();
     });
 
-    test('should handle errors in handlers created by createEventHandler gracefully', () => {
+    test('createEventHandlerで生成したハンドラの例外を握りつぶす', () => {
       const erroringHandler = jest.fn(() => { throw new Error('Test Error from createEventHandler'); });
       eventManager.addEventListener('domEvent', erroringHandler);
       jest.spyOn(console, 'error').mockImplementation(() => {});

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -31,28 +31,19 @@ describe('Event Handlers', () => {
   });
 
   describe('handleKeyDown', () => {
-    test('ArrowLeftが押されたときにmovePiece(-1)を呼び出す', () => {
-      const event = { key: 'ArrowLeft', repeat: false };
+    test.each([
+      ['ArrowLeft', 'movePiece', [-1]],
+      ['ArrowRight', 'movePiece', [1]],
+      ['ArrowDown', 'dropPiece', []],
+      ['ArrowUp', 'rotatePiece', [1]],
+    ])('%sキーで適切なメソッドが呼び出される', (key, method, args) => {
+      const event = { key, repeat: false };
       handleKeyDown(event, mockGameInstance);
-      expect(mockGameInstance.movePiece).toHaveBeenCalledWith(-1);
-    });
-
-    test('ArrowRightが押されたときにmovePiece(1)を呼び出す', () => {
-      const event = { key: 'ArrowRight', repeat: false };
-      handleKeyDown(event, mockGameInstance);
-      expect(mockGameInstance.movePiece).toHaveBeenCalledWith(1);
-    });
-
-    test('ArrowDownが押されたときにdropPieceを呼び出す', () => {
-      const event = { key: 'ArrowDown', repeat: false };
-      handleKeyDown(event, mockGameInstance);
-      expect(mockGameInstance.dropPiece).toHaveBeenCalledTimes(1);
-    });
-
-    test('ArrowUpが押されたときにrotatePiece(1)を呼び出す', () => {
-      const event = { key: 'ArrowUp', repeat: false };
-      handleKeyDown(event, mockGameInstance);
-      expect(mockGameInstance.rotatePiece).toHaveBeenCalledWith(1);
+      if (args.length) {
+        expect(mockGameInstance[method]).toHaveBeenCalledWith(...args);
+      } else {
+        expect(mockGameInstance[method]).toHaveBeenCalled();
+      }
     });
 
     test('スペースキーが押されたときにハードドロップを実行する', () => {

--- a/tests/game/GameFunctions.test.js
+++ b/tests/game/GameFunctions.test.js
@@ -55,6 +55,7 @@ jest.mock('../../src/game', () => {
 
 // テスト用のモジュールをインポート
 const gameModule = require('../../src/game');
+const { setupGameDOM, setupDOM } = require("../helpers/testUtils");
 
 
 // モック化された関数やオブジェクトを取得
@@ -77,79 +78,12 @@ const {
 
 
 // Game Helper Functions用のsetupDOM（canvasやモック要素込み）
-const setupGameDOM = () => {
-  document.body.innerHTML = [
-    '<canvas id="game"></canvas>',
-    '<canvas id="next-piece-canvas"></canvas>',
-    '<div id="score"></div>',
-    '<div id="lines"></div>',
-    '<div id="level"></div>'
-  ].join('');
-  // ...（以下、元の内容を流用）
-  const gameCanvasElement = {
-    id: 'game',
-    width: 0,
-    height: 0,
-    getContext: jest.fn(() => global.mockCtx)
-  };
-  const mockNextPieceCanvas = {
-    id: 'next-piece-canvas',
-    width: 300,
-    height: 150,
-    getContext: jest.fn(() => global.mockCtx)
-  };
-  const mockScoreElement = {
-    id: 'score',
-    textContent: '0'
-  };
-  const mockLinesElement = {
-    id: 'lines',
-    textContent: '0'
-  };
-  const mockLevelElement = {
-    id: 'level',
-    textContent: '1'
-  };
-  document.getElementById = jest.fn((id) => {
-    switch (id) {
-      case 'game':
-        return gameCanvasElement;
-      case 'next-piece-canvas':
-        return mockNextPieceCanvas;
-      case 'score':
-        return mockScoreElement;
-      case 'lines':
-        return mockLinesElement;
-      case 'level':
-        return mockLevelElement;
-      default:
-        return null;
-    }
-  });
-  return {
-    gameCanvasElement,
-    mockNextPieceCanvas,
-    mockScoreElement,
-    mockLinesElement,
-    mockLevelElement,
-  };
-};
-
-// 表示系テスト専用のシンプルなsetupDOM
-const setupDisplayDOM = (ids) => {
-  if (!Array.isArray(ids)) throw new Error('setupDisplayDOMには配列を渡してください');
-  document.body.innerHTML = ids.map(id => `<div id="${id}"></div>`).join('');
-  return ids.reduce((acc, id) => {
-    acc[id] = document.getElementById(id);
-    return acc;
-  }, {});
-};
 
 afterEach(() => {
   jest.restoreAllMocks();
 });
 
-describe('Game Helper Functions', () => {
+describe('ゲームヘルパー関数', () => {
   let draw, drawMatrix, tetrisGame, gameState, mockCtx, mockCanvas, mockNextPieceCanvas, mockScoreElement, mockLinesElement, mockLevelElement;
   let mockState;
 
@@ -210,7 +144,7 @@ describe('Game Helper Functions', () => {
   });
 
   describe('drawMatrix', () => {
-    test('should call fillRect for non-zero matrix values', () => {
+    test('0以外の値のみ描画する', () => {
       // テスト用のパラメータを設定
       const testCtx = {
         fillStyle: '',
@@ -270,7 +204,7 @@ describe('Game Helper Functions', () => {
   });
 
   describe('draw', () => {
-    test('should clear background and draw board and piece', () => {
+    test('背景をクリアして描画する', () => {
       // テスト用のパラメータを設定
       const testCtx = {
         clearRect: jest.fn(),
@@ -314,15 +248,6 @@ describe('Game Helper Functions', () => {
     });
   });
 
-// DOMセットアップ用のヘルパー
-const setupDOM = (ids) => {
-  if (!Array.isArray(ids)) throw new Error('setupDOMには配列を渡してください');
-  document.body.innerHTML = ids.map(id => `<div id="${id}"></div>`).join('');
-  return ids.reduce((acc, id) => {
-    acc[id] = document.getElementById(id);
-    return acc;
-  }, {});
-};
 
   describe('表示系ヘルパー関数', () => {
     let elements;
@@ -335,7 +260,7 @@ const setupDOM = (ids) => {
       ['ライン数を更新するとDOMに値が反映される', 'lines', 4, '4'],
       ['レベルを更新するとDOMに値が反映される', 'level', 2, '2'],
     ])('%s', (_desc, id, value, expected) => {
-      elements = setupDisplayDOM([id]);
+      elements = setupDOM([id]);
       const element = elements[id];
       if (element) element.textContent = String(value);
       expect(element.textContent).toBe(expected);

--- a/tests/game/InitReturn.test.js
+++ b/tests/game/InitReturn.test.js
@@ -1,24 +1,16 @@
+import { setupGameDOM } from '../helpers/testUtils.js';
 import { init } from '../../src/game.js';
 
 describe('init関数の返り値', () => {
   beforeEach(() => {
-    document.body.innerHTML = [
-      '<canvas id="game"></canvas>',
-      '<canvas id="next-piece-canvas"></canvas>',
-      '<div id="score"></div>',
-      '<div id="lines"></div>',
-      '<div id="level"></div>'
-    ].join('');
-
-    const canvas = document.getElementById('game');
-    canvas.getContext = jest.fn(() => ({
-      fillRect: jest.fn(),
-      clearRect: jest.fn(),
-    }));
-
+    global.mockCtx = { fillRect: jest.fn(), clearRect: jest.fn() };
+    setupGameDOM();
+    const canvas = document.getElementById("game");
+    canvas.getContext = jest.fn(() => global.mockCtx);
     document.addEventListener = jest.fn();
     document.removeEventListener = jest.fn();
   });
+
 
   afterEach(() => {
     jest.restoreAllMocks();

--- a/tests/helpers/testUtils.js
+++ b/tests/helpers/testUtils.js
@@ -1,0 +1,59 @@
+export const setupGameDOM = () => {
+  document.body.innerHTML = [
+    '<canvas id="game"></canvas>',
+    '<canvas id="next-piece-canvas"></canvas>',
+    '<div id="score"></div>',
+    '<div id="lines"></div>',
+    '<div id="level"></div>'
+  ].join('');
+
+  const gameCanvasElement = {
+    id: 'game',
+    width: 0,
+    height: 0,
+    getContext: jest.fn(() => global.mockCtx)
+  };
+  const mockNextPieceCanvas = {
+    id: 'next-piece-canvas',
+    width: 300,
+    height: 150,
+    getContext: jest.fn(() => global.mockCtx)
+  };
+  const mockScoreElement = { id: 'score', textContent: '0' };
+  const mockLinesElement = { id: 'lines', textContent: '0' };
+  const mockLevelElement = { id: 'level', textContent: '1' };
+
+  document.getElementById = jest.fn((id) => {
+    switch (id) {
+      case 'game':
+        return gameCanvasElement;
+      case 'next-piece-canvas':
+        return mockNextPieceCanvas;
+      case 'score':
+        return mockScoreElement;
+      case 'lines':
+        return mockLinesElement;
+      case 'level':
+        return mockLevelElement;
+      default:
+        return null;
+    }
+  });
+
+  return {
+    gameCanvasElement,
+    mockNextPieceCanvas,
+    mockScoreElement,
+    mockLinesElement,
+    mockLevelElement,
+  };
+};
+
+export const setupDOM = (ids) => {
+  if (!Array.isArray(ids)) throw new Error('setupDOMには配列を渡してください');
+  document.body.innerHTML = ids.map(id => `<div id="${id}"></div>`).join('');
+  return ids.reduce((acc, id) => {
+    acc[id] = document.getElementById(id);
+    return acc;
+  }, {});
+};

--- a/tests/index/AutoStart.test.js
+++ b/tests/index/AutoStart.test.js
@@ -1,3 +1,4 @@
+import { setupDOM } from '../helpers/testUtils.js';
 import { jest } from '@jest/globals';
 
 jest.mock('../../src/styles.css', () => ({}), { virtual: true });
@@ -10,7 +11,7 @@ beforeEach(() => {
     init: jest.fn(),
   }));
   ({ init } = require('../../src/game.js'));
-  document.body.innerHTML = '<canvas id="game"></canvas>';
+  setupDOM(['game']);
 });
 describe('index.js 自動起動テスト', () => {
   test('DOMContentLoaded で init が呼び出される', () => {


### PR DESCRIPTION
## Summary
- 共通DOM操作を `tests/helpers/testUtils.js` として切り出し
- テスト名や `describe` 名を日本語に統一
- `test.each` を用いてキーボード入力テストをパラメータ化
- 各テストを修正し共通ヘルパーを利用

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68510670361c8321af2d347a8ef861f0