### PR TITLE
move handlers into GameUI

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -1,5 +1,6 @@
 import { Game } from './core/Game.js';
 import { GAME_CONSTANTS } from './constants/game.js';
+import { GameUI } from './ui/GameUI.js';
 
 // ゲームの状態とロジックをカプセル化
 export const tetrisGame = new Game();
@@ -225,90 +226,30 @@ export function update(time = 0) {
     playerDrop();
   }
 
-  draw(gameState.ctx, gameState.board, gameState.piece, tetrisGame.nextPiece, GAME_CONSTANTS.COLORS, GAME_CONSTANTS.BLOCK_SIZE);
+  draw(
+    gameState.ctx,
+    gameState.board,
+    gameState.piece,
+    tetrisGame.nextPiece,
+    GAME_CONSTANTS.COLORS,
+    GAME_CONSTANTS.BLOCK_SIZE
+  );
   gameState.gameLoopId = requestAnimationFrame(update);
 }
 
-// キーハンドラ関数
-export function handleKeyDown(event, gameInstance) {
-  if (gameInstance.isGameOver) return;
+// GameUIインスタンス生成
+export const gameUI = new GameUI(gameState, {
+  movePiece: tetrisGame.movePiece.bind(tetrisGame),
+  dropPiece: tetrisGame.dropPiece.bind(tetrisGame),
+  rotatePiece: tetrisGame.rotatePiece.bind(tetrisGame),
+  update,
+  resetGame,
+});
 
-  // キーリピートを無視
-  if (event.repeat) return;
-
-  gameInstance.keys[event.key] = true;
-
-  switch (event.key) {
-    case 'ArrowLeft':
-      gameInstance.movePiece(-1);
-      break;
-    case 'ArrowRight':
-      gameInstance.movePiece(1);
-      break;
-    case 'ArrowDown':
-      gameInstance.dropPiece();
-      break;
-    case 'ArrowUp':
-      gameInstance.rotatePiece(1);
-      break;
-    case ' ': // スペースキー
-      // ハードドロップ
-      console.log('handleKeyDown: ハードドロップを実行します');
-      if (!gameInstance.piece) {
-        console.warn('handleKeyDown: アクティブなピースがありません');
-        break;
-      }
-
-      // ピースを一番下まで落とす
-      while (true) {
-        const pieceY = gameInstance.piece.pos.y;
-        gameInstance.dropPiece();
-        // 位置が変わらなくなったら終了
-        if (pieceY === gameInstance.piece.pos.y || gameInstance.isGameOver) {
-          console.log('handleKeyDown: ハードドロップ完了', { y: gameInstance.piece?.pos.y });
-          break;
-        }
-      }
-      break;
-    case 'p':
-    case 'P':
-      // 一時停止
-      if (gameInstance.gameLoopId) {
-        cancelAnimationFrame(gameInstance.gameLoopId);
-        gameInstance.gameLoopId = null;
-        gameInstance.paused = true; // ポーズ状態を設定
-      } else {
-        gameInstance.paused = false; // ポーズ状態を解除
-        gameInstance.lastTime = 0;
-        gameInstance.gameLoopId = requestAnimationFrame(gameInstance.update);
-      }
-      break;
-    case 'r':
-    case 'R':
-      // リセット
-      gameInstance.resetGame();
-      break;
-  }
-}
-
-export function handleKeyUp(event, gameInstance) {
-  gameInstance.keys[event.key] = false;
-}
-
-// イベントリスナーの設定
-export function setupEventListeners(keyDownHandler, keyUpHandler) {
-  console.log('setupEventListeners: イベントリスナーを設定します');
-
-  // 既存のイベントリスナーを削除
-  document.removeEventListener('keydown', keyDownHandler);
-  document.removeEventListener('keyup', keyUpHandler);
-
-  // 新しいイベントリスナーを追加
-  document.addEventListener('keydown', keyDownHandler);
-  document.addEventListener('keyup', keyUpHandler);
-
-  console.log('setupEventListeners: イベントリスナーの設定が完了しました');
-}
+// ラッパー関数として公開
+export const handleKeyDown = gameUI.onKeyDown;
+export const handleKeyUp = gameUI.onKeyUp;
+export const setupEventListeners = gameUI.setupEventListeners;
 
 // ゲーム初期化
 export function init() {
@@ -332,25 +273,7 @@ export function init() {
 
     // イベントリスナーを設定
     console.log('init: イベントリスナーを設定します');
-    setupEventListeners(
-      (event) => handleKeyDown(event, {
-        isGameOver: gameState.isGameOver,
-        keys: gameState.keys,
-        piece: gameState.piece,
-        gameLoopId: gameState.gameLoopId,
-        paused: gameState.paused,
-        lastTime: gameState.lastTime,
-        // tetrisGameのメソッドを直接参照
-        movePiece: tetrisGame.movePiece.bind(tetrisGame),
-        dropPiece: tetrisGame.dropPiece.bind(tetrisGame),
-        rotatePiece: tetrisGame.rotatePiece.bind(tetrisGame),
-        update: update,
-        resetGame: resetGame,
-      }),
-      (event) => handleKeyUp(event, {
-        keys: gameState.keys,
-      })
-    );
+    setupEventListeners();
 
     console.log('init: ゲームの初期化が完了しました');
 

--- a/src/ui/GameUI.js
+++ b/src/ui/GameUI.js
@@ -1,0 +1,73 @@
+export class GameUI {
+  constructor(game) {
+    this.game = game;
+  }
+
+  onKeyDown = (event) => {
+    if (this.game.isGameOver) return;
+    if (event.repeat) return;
+
+    this.game.keys[event.key] = true;
+
+    switch (event.key) {
+      case 'ArrowLeft':
+        this.game.movePiece(-1);
+        break;
+      case 'ArrowRight':
+        this.game.movePiece(1);
+        break;
+      case 'ArrowDown':
+        this.game.dropPiece();
+        break;
+      case 'ArrowUp':
+        this.game.rotatePiece(1);
+        break;
+      case ' ': // ハードドロップ
+        console.log('handleKeyDown: ハードドロップを実行します');
+        if (!this.game.piece) {
+          console.warn('handleKeyDown: アクティブなピースがありません');
+          break;
+        }
+        while (true) {
+          const pieceY = this.game.piece.pos.y;
+          this.game.dropPiece();
+          if (pieceY === this.game.piece.pos.y || this.game.isGameOver) {
+            console.log('handleKeyDown: ハードドロップ完了', { y: this.game.piece?.pos.y });
+            break;
+          }
+        }
+        break;
+      case 'p':
+      case 'P':
+        if (this.game.gameLoopId) {
+          cancelAnimationFrame(this.game.gameLoopId);
+          this.game.gameLoopId = null;
+          this.game.paused = true;
+        } else {
+          this.game.paused = false;
+          this.game.lastTime = 0;
+          this.game.gameLoopId = requestAnimationFrame(this.game.update);
+        }
+        break;
+      case 'r':
+      case 'R':
+        this.game.resetGame();
+        break;
+    }
+  };
+
+  onKeyUp = (event) => {
+    this.game.keys[event.key] = false;
+  };
+
+  setupEventListeners = () => {
+    console.log('setupEventListeners: イベントリスナーを設定します');
+    document.removeEventListener('keydown', this.onKeyDown);
+    document.removeEventListener('keyup', this.onKeyUp);
+    document.addEventListener('keydown', this.onKeyDown);
+    document.addEventListener('keyup', this.onKeyUp);
+    console.log('setupEventListeners: イベントリスナーの設定が完了しました');
+  };
+}
+
+export default GameUI;

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -1,8 +1,9 @@
 import 'core-js/stable';
-import { handleKeyDown, handleKeyUp, setupEventListeners } from '../src/game.js';
+import { GameUI } from '../src/ui/GameUI.js';
 
 describe('Event Handlers', () => {
   let mockGameInstance;
+  let gameUI;
   let addEventListenerSpy;
   let removeEventListenerSpy;
 
@@ -21,6 +22,8 @@ describe('Event Handlers', () => {
       resetGame: jest.fn(),
     };
 
+    gameUI = new GameUI(mockGameInstance);
+
     // document.addEventListener と removeEventListener をモック
     addEventListenerSpy = jest.spyOn(document, 'addEventListener');
     removeEventListenerSpy = jest.spyOn(document, 'removeEventListener');
@@ -30,34 +33,34 @@ describe('Event Handlers', () => {
     jest.restoreAllMocks();
   });
 
-  describe('handleKeyDown', () => {
+  describe('onKeyDown', () => {
     test('ArrowLeftが押されたときにmovePiece(-1)を呼び出す', () => {
       const event = { key: 'ArrowLeft', repeat: false };
-      handleKeyDown(event, mockGameInstance);
+      gameUI.onKeyDown(event);
       expect(mockGameInstance.movePiece).toHaveBeenCalledWith(-1);
     });
 
     test('ArrowRightが押されたときにmovePiece(1)を呼び出す', () => {
       const event = { key: 'ArrowRight', repeat: false };
-      handleKeyDown(event, mockGameInstance);
+      gameUI.onKeyDown(event);
       expect(mockGameInstance.movePiece).toHaveBeenCalledWith(1);
     });
 
     test('ArrowDownが押されたときにdropPieceを呼び出す', () => {
       const event = { key: 'ArrowDown', repeat: false };
-      handleKeyDown(event, mockGameInstance);
+      gameUI.onKeyDown(event);
       expect(mockGameInstance.dropPiece).toHaveBeenCalledTimes(1);
     });
 
     test('ArrowUpが押されたときにrotatePiece(1)を呼び出す', () => {
       const event = { key: 'ArrowUp', repeat: false };
-      handleKeyDown(event, mockGameInstance);
+      gameUI.onKeyDown(event);
       expect(mockGameInstance.rotatePiece).toHaveBeenCalledWith(1);
     });
 
     test('スペースキーが押されたときにハードドロップを実行する', () => {
       const event = { key: ' ', repeat: false };
-      handleKeyDown(event, mockGameInstance);
+      gameUI.onKeyDown(event);
       // ハードドロップはdropPieceを複数回呼び出す
       expect(mockGameInstance.dropPiece).toHaveBeenCalled();
     });
@@ -66,14 +69,14 @@ describe('Event Handlers', () => {
       const event = { key: 'p', repeat: false };
       
       // 最初の呼び出し: ポーズ
-      handleKeyDown(event, mockGameInstance);
+      gameUI.onKeyDown(event);
       expect(mockGameInstance.gameLoopId).toBeNull();
       expect(mockGameInstance.paused).toBe(true);
 
       // 2回目の呼び出し: ポーズ解除
       // requestAnimationFrameをモックして、gameLoopIdがセットされることを確認
       const mockRequestAnimationFrame = jest.spyOn(window, 'requestAnimationFrame').mockReturnValueOnce(456);
-      handleKeyDown(event, mockGameInstance);
+      gameUI.onKeyDown(event);
       expect(mockGameInstance.paused).toBe(false);
       expect(mockGameInstance.gameLoopId).toBe(456);
       mockRequestAnimationFrame.mockRestore();
@@ -81,44 +84,41 @@ describe('Event Handlers', () => {
 
     test('Rキーが押されたときにresetGameを呼び出す', () => {
       const event = { key: 'r', repeat: false };
-      handleKeyDown(event, mockGameInstance);
+      gameUI.onKeyDown(event);
       expect(mockGameInstance.resetGame).toHaveBeenCalledTimes(1);
     });
 
     test('キーリピート時は処理をスキップする', () => {
       const event = { key: 'ArrowLeft', repeat: true };
-      handleKeyDown(event, mockGameInstance);
+      gameUI.onKeyDown(event);
       expect(mockGameInstance.movePiece).not.toHaveBeenCalled();
     });
 
     test('ゲームオーバー時はキー入力を無視する', () => {
       mockGameInstance.isGameOver = true;
       const event = { key: 'ArrowLeft', repeat: false };
-      handleKeyDown(event, mockGameInstance);
+      gameUI.onKeyDown(event);
       expect(mockGameInstance.movePiece).not.toHaveBeenCalled();
     });
   });
 
-  describe('handleKeyUp', () => {
+  describe('onKeyUp', () => {
     test('キーが離されたときにkeysの状態をfalseにする', () => {
       mockGameInstance.keys['ArrowLeft'] = true;
       const event = { key: 'ArrowLeft' };
-      handleKeyUp(event, mockGameInstance);
+      gameUI.onKeyUp(event);
       expect(mockGameInstance.keys['ArrowLeft']).toBe(false);
     });
   });
 
   describe('setupEventListeners', () => {
     test('keydownとkeyupイベントリスナーを登録する', () => {
-      const mockKeyDownHandler = jest.fn();
-      const mockKeyUpHandler = jest.fn();
+      gameUI.setupEventListeners();
 
-      setupEventListeners(mockKeyDownHandler, mockKeyUpHandler);
-
-      expect(removeEventListenerSpy).toHaveBeenCalledWith('keydown', mockKeyDownHandler);
-      expect(removeEventListenerSpy).toHaveBeenCalledWith('keyup', mockKeyUpHandler);
-      expect(addEventListenerSpy).toHaveBeenCalledWith('keydown', mockKeyDownHandler);
-      expect(addEventListenerSpy).toHaveBeenCalledWith('keyup', mockKeyUpHandler);
+      expect(removeEventListenerSpy).toHaveBeenCalledWith('keydown', gameUI.onKeyDown);
+      expect(removeEventListenerSpy).toHaveBeenCalledWith('keyup', gameUI.onKeyUp);
+      expect(addEventListenerSpy).toHaveBeenCalledWith('keydown', gameUI.onKeyDown);
+      expect(addEventListenerSpy).toHaveBeenCalledWith('keyup', gameUI.onKeyUp);
     });
   });
 });

--- a/tests/ui/GameUIHandlers.test.js
+++ b/tests/ui/GameUIHandlers.test.js
@@ -1,0 +1,61 @@
+import { GameUI } from '../../src/ui/GameUI.js';
+
+describe('GameUI メソッド', () => {
+  let mockGame;
+  let ui;
+  let addSpy;
+  let removeSpy;
+
+  beforeEach(() => {
+    mockGame = {
+      isGameOver: false,
+      keys: {},
+      piece: { pos: { y: 0 } },
+      gameLoopId: 0,
+      paused: false,
+      lastTime: 0,
+      movePiece: jest.fn(),
+      dropPiece: jest.fn(),
+      rotatePiece: jest.fn(),
+      update: jest.fn(),
+      resetGame: jest.fn(),
+    };
+    ui = new GameUI(mockGame);
+    addSpy = jest.spyOn(document, 'addEventListener');
+    removeSpy = jest.spyOn(document, 'removeEventListener');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('onKeyDown', () => {
+    test('ArrowLeft で movePiece(-1) が呼ばれる', () => {
+      ui.onKeyDown({ key: 'ArrowLeft', repeat: false });
+      expect(mockGame.movePiece).toHaveBeenCalledWith(-1);
+    });
+
+    test('repeat 時は何もしない', () => {
+      ui.onKeyDown({ key: 'ArrowLeft', repeat: true });
+      expect(mockGame.movePiece).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onKeyUp', () => {
+    test('キー状態を false にする', () => {
+      mockGame.keys['a'] = true;
+      ui.onKeyUp({ key: 'a' });
+      expect(mockGame.keys['a']).toBe(false);
+    });
+  });
+
+  describe('setupEventListeners', () => {
+    test('DOM にイベントを登録する', () => {
+      ui.setupEventListeners();
+      expect(removeSpy).toHaveBeenCalledWith('keydown', ui.onKeyDown);
+      expect(removeSpy).toHaveBeenCalledWith('keyup', ui.onKeyUp);
+      expect(addSpy).toHaveBeenCalledWith('keydown', ui.onKeyDown);
+      expect(addSpy).toHaveBeenCalledWith('keyup', ui.onKeyUp);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- 抽出した GameUI クラスを新設し、キー入力処理を移動
- game.js では GameUI インスタンスを利用
- イベントハンドラテストを GameUI に合わせて更新
- GameUI 単体のテストを追加

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851063457e883219f731c11c0292629