### PR TITLE
ゲームUIクラス追加とハンドラ移動

### DIFF
--- a/src/ui/GameUI.js
+++ b/src/ui/GameUI.js
@@ -1,0 +1,66 @@
+export default class GameUI {
+  constructor(state, actions) {
+    this.state = state;
+    this.actions = actions;
+    this.onKeyDown = this.onKeyDown.bind(this);
+    this.onKeyUp = this.onKeyUp.bind(this);
+  }
+
+  onKeyDown(event) {
+    const { state, actions } = this;
+    if (state.isGameOver) return;
+    if (event.repeat) return;
+    state.keys[event.key] = true;
+
+    switch (event.key) {
+      case 'ArrowLeft':
+        actions.movePiece(-1);
+        break;
+      case 'ArrowRight':
+        actions.movePiece(1);
+        break;
+      case 'ArrowDown':
+        actions.dropPiece();
+        break;
+      case 'ArrowUp':
+        actions.rotatePiece(1);
+        break;
+      case ' ':
+        while (true) {
+          const y = state.piece?.pos.y;
+          actions.dropPiece();
+          if (y === state.piece?.pos.y || state.isGameOver) {
+            break;
+          }
+        }
+        break;
+      case 'p':
+      case 'P':
+        if (state.gameLoopId) {
+          cancelAnimationFrame(state.gameLoopId);
+          state.gameLoopId = null;
+          state.paused = true;
+        } else {
+          state.paused = false;
+          state.lastTime = 0;
+          state.gameLoopId = requestAnimationFrame(actions.update);
+        }
+        break;
+      case 'r':
+      case 'R':
+        actions.resetGame();
+        break;
+    }
+  }
+
+  onKeyUp(event) {
+    this.state.keys[event.key] = false;
+  }
+
+  setupEventListeners(keyDownHandler = this.onKeyDown, keyUpHandler = this.onKeyUp) {
+    document.removeEventListener('keydown', keyDownHandler);
+    document.removeEventListener('keyup', keyUpHandler);
+    document.addEventListener('keydown', keyDownHandler);
+    document.addEventListener('keyup', keyUpHandler);
+  }
+}

--- a/tests/ui/GameUI.test.js
+++ b/tests/ui/GameUI.test.js
@@ -1,0 +1,104 @@
+import GameUI from '../../src/ui/GameUI.js';
+
+describe('GameUI メソッド', () => {
+  let gameInstance;
+  let ui;
+  let addEventListenerSpy;
+  let removeEventListenerSpy;
+
+  beforeEach(() => {
+    gameInstance = {
+      isGameOver: false,
+      keys: {},
+      piece: { pos: { y: 0 } },
+      gameLoopId: 123,
+      paused: false,
+      lastTime: 0,
+      movePiece: jest.fn(),
+      dropPiece: jest.fn(),
+      rotatePiece: jest.fn(),
+      update: jest.fn(),
+      resetGame: jest.fn(),
+    };
+    ui = new GameUI(gameInstance, gameInstance);
+    addEventListenerSpy = jest.spyOn(document, 'addEventListener');
+    removeEventListenerSpy = jest.spyOn(document, 'removeEventListener');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('onKeyDown', () => {
+    test.each([
+      ['ArrowLeft', 'movePiece', [-1]],
+      ['ArrowRight', 'movePiece', [1]],
+      ['ArrowDown', 'dropPiece', []],
+      ['ArrowUp', 'rotatePiece', [1]],
+    ])('%sキーで適切なメソッドが呼び出される', (key, method, args) => {
+      const event = { key, repeat: false };
+      ui.onKeyDown(event);
+      if (args.length) {
+        expect(gameInstance[method]).toHaveBeenCalledWith(...args);
+      } else {
+        expect(gameInstance[method]).toHaveBeenCalled();
+      }
+    });
+
+    test('スペースキーでハードドロップを実行する', () => {
+      const event = { key: ' ', repeat: false };
+      ui.onKeyDown(event);
+      expect(gameInstance.dropPiece).toHaveBeenCalled();
+    });
+
+    test('Pキーでポーズ/解除が切り替わる', () => {
+      const event = { key: 'p', repeat: false };
+      ui.onKeyDown(event);
+      expect(gameInstance.gameLoopId).toBeNull();
+      expect(gameInstance.paused).toBe(true);
+      const mockRequest = jest.spyOn(window, 'requestAnimationFrame').mockReturnValueOnce(456);
+      ui.onKeyDown(event);
+      expect(gameInstance.paused).toBe(false);
+      expect(gameInstance.gameLoopId).toBe(456);
+      mockRequest.mockRestore();
+    });
+
+    test('RキーでresetGameが呼び出される', () => {
+      const event = { key: 'r', repeat: false };
+      ui.onKeyDown(event);
+      expect(gameInstance.resetGame).toHaveBeenCalled();
+    });
+
+    test('キーリピート時は処理しない', () => {
+      const event = { key: 'ArrowLeft', repeat: true };
+      ui.onKeyDown(event);
+      expect(gameInstance.movePiece).not.toHaveBeenCalled();
+    });
+
+    test('ゲームオーバー時は入力を無視する', () => {
+      gameInstance.isGameOver = true;
+      const event = { key: 'ArrowLeft', repeat: false };
+      ui.onKeyDown(event);
+      expect(gameInstance.movePiece).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onKeyUp', () => {
+    test('キーが離されたときに状態を更新する', () => {
+      gameInstance.keys['ArrowLeft'] = true;
+      const event = { key: 'ArrowLeft' };
+      ui.onKeyUp(event);
+      expect(gameInstance.keys['ArrowLeft']).toBe(false);
+    });
+  });
+
+  describe('setupEventListeners', () => {
+    test('documentへのリスナー登録が行われる', () => {
+      ui.setupEventListeners();
+      expect(removeEventListenerSpy).toHaveBeenCalledWith('keydown', ui.onKeyDown);
+      expect(removeEventListenerSpy).toHaveBeenCalledWith('keyup', ui.onKeyUp);
+      expect(addEventListenerSpy).toHaveBeenCalledWith('keydown', ui.onKeyDown);
+      expect(addEventListenerSpy).toHaveBeenCalledWith('keyup', ui.onKeyUp);
+    });
+  });
+});


### PR DESCRIPTION
## Notes
- `src/game.js` の `handleKeyDown`、`handleKeyUp`、`setupEventListeners` を `GameUI` クラスに移植しました
- 既存関数は `GameUI` を利用するラッパーとして残しています
- 初期化処理では `setupEventListeners()` を呼び出すだけで済むようになりました
- 各メソッドの単体テストを `tests/ui/GameUI.test.js` に追加しました

## Summary
- `GameUI` クラスを新規作成しキー入力処理を実装【F:src/ui/GameUI.js†L1-L66】
- `src/game.js` で `gameUI` インスタンスを生成し既存ハンドラをラップ【F:src/game.js†L232-L256】
- `init` 内のイベント登録を簡素化【F:src/game.js†L272-L284】
- 新しいテスト `tests/ui/GameUI.test.js` を追加【F:tests/ui/GameUI.test.js†L1-L78】

## Testing
- `npm install --silent`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68510a81e4288321b8f5d31f94179039